### PR TITLE
Support Putty/modern-SSH tools

### DIFF
--- a/src/auth/multiContainerAuth.coffee
+++ b/src/auth/multiContainerAuth.coffee
@@ -52,7 +52,7 @@ module.exports = (session) ->
         return ctx.accept()
       else
         log.warn {user: ctx.username, password: ctx.password}, 'Authentication failed'
-    ctx.reject()
+    ctx.reject(['password'])
 
 
   #


### PR DESCRIPTION
Fix for `Disconnected: No supported authentication methods available (server sent: )` Adapted from https://github.com/jeroenpeeters/docker-ssh/issues/18